### PR TITLE
Integration with custom Device Handlers

### DIFF
--- a/smartapps/kristopherkubicki/circadian-daylight.src/circadian-daylight.groovy
+++ b/smartapps/kristopherkubicki/circadian-daylight.src/circadian-daylight.groovy
@@ -163,31 +163,41 @@ def modeHandler(evt) {
     def bright = getBright()
     for(ctbulb in ctbulbs) {
         if(ctbulb.currentValue("switch") == "on") {
-            if(settings.dbright == true && ctbulb.currentValue("level") != bright) {
-                ctbulb.setLevel(bright)
-            }
-            if(ctbulb.currentValue("colormode") != "ct" || ctbulb.currentValue("colorTemperature") != ct) {
-                ctbulb.setColorTemperature(ct)
-            }
+            if(settings.dbright == true && ctbulb.currentValue("cdBrightness") != "false") {
+				if(ctbulb.currentValue("level") != bright) {
+					ctbulb.setLevel(bright)
+				}
+			}
+			if(ctbulb.currentValue("cdColor") != "false") {
+				if(ctbulb.currentValue("colormode") != "ct" || ctbulb.currentValue("colorTemperature") != ct) {
+					ctbulb.setColorTemperature(ct)
+				}
+			}
         }
     }
     def color = [hex: hex, hue: hsv.h, saturation: hsv.s, level: bright]
     for(bulb in bulbs) {
         if(bulb.currentValue("switch") == "on") {
-        	if(settings.dbright == true && bulb.currentValue("level") != bright) {
-                bulb.setLevel(bright)
-            }
-            if((bulb.currentValue("colormode") != "xy" && bulb.currentValue("colormode") != "hs") || bulb.currentValue("color") != hex) {
-            	color.value = bulb.currentValue("level")
-            	bulb.setColor(color)
+        	if(settings.dbright == true && bulb.currentValue("cdBrightness") != "false") {
+				if(bulb.currentValue("level") != bright) {
+					bulb.setLevel(bright)
+				}
+			}
+			if(bulb.currentValue("cdColor") != "false") {
+				if((bulb.currentValue("colormode") != "xy" && bulb.currentValue("colormode") != "hs") || bulb.currentValue("color") != hex) {
+					color.value = bulb.currentValue("level")
+					bulb.setColor(color)
+				}
 			}
         }
     }
     for(dimmer in dimmers) {
         if(dimmer.currentValue("switch") == "on") {
-        	if(dimmer.currentValue("level") != bright) {
-            	dimmer.setLevel(bright)
-            }
+        	if(ctbulb.currentValue("cdBrightness") != "false") {
+				if(dimmer.currentValue("level") != bright) {
+					dimmer.setLevel(bright)
+				}
+			}
         }
     }
     

--- a/smartapps/kristopherkubicki/circadian-daylight.src/circadian-daylight.groovy
+++ b/smartapps/kristopherkubicki/circadian-daylight.src/circadian-daylight.groovy
@@ -176,12 +176,14 @@ def modeHandler(evt) {
         if(ctbulb.currentValue("switch") == "on") {
             if(settings.dbright == true && ctbulb.currentValue("cdBrightness") != "false") {
 				if(ctbulb.currentValue("level") != bright) {
-					ctbulb.setLevel(bright)
+					if(ctbulb.currentValue("cdBrightness") == "true") { ctbulb.setLevel(bright, false) } //Prevent CD from getting disabled, if compatible
+					else { ctbulb.setLevel(bright) }
 				}
 			}
 			if(ctbulb.currentValue("cdColor") != "false") {
 				if(ctbulb.currentValue("colormode") != "ct" || ctbulb.currentValue("colorTemperature") != ct) {
-					ctbulb.setColorTemperature(ct)
+					if(ctbulb.currentValue("cdColor") == "true") { ctbulb.setColorTemperature(ct, false) } //Prevent CD from getting disabled, if compatible
+					else { ctbulb.setColorTemperature(ct) }
 				}
 			}
         }
@@ -191,12 +193,14 @@ def modeHandler(evt) {
         if(bulb.currentValue("switch") == "on") {
         	if(settings.dbright == true && bulb.currentValue("cdBrightness") != "false") {
 				if(bulb.currentValue("level") != bright) {
-					bulb.setLevel(bright)
+					if(bulb.currentValue("cdBrightness") == "true") { bulb.setLevel(bright, false) } //Prevent CD from getting disabled, if compatible
+					else { bulb.setLevel(bright) }
 				}
 			}
 			if(bulb.currentValue("cdColor") != "false") {
 				if((bulb.currentValue("colormode") != "xy" && bulb.currentValue("colormode") != "hs") || bulb.currentValue("color") != hex) {
 					color.value = bulb.currentValue("level")
+					if(bulb.currentValue("cdColor") == "true") { color.disableCDColor = false } //Prevent CD from getting disabled, if compatible
 					bulb.setColor(color)
 				}
 			}
@@ -204,9 +208,10 @@ def modeHandler(evt) {
     }
     for(dimmer in dimmers) {
         if(dimmer.currentValue("switch") == "on") {
-        	if(ctbulb.currentValue("cdBrightness") != "false") {
+        	if(dimmer.currentValue("cdBrightness") != "false") {
 				if(dimmer.currentValue("level") != bright) {
-					dimmer.setLevel(bright)
+					if(dimmer.currentValue("cdBrightness") == "true") { dimmer.setLevel(bright, false) } //Prevent CD from getting disabled, if compatible
+					else { dimmer.setLevel(bright) }
 				}
 			}
         }

--- a/smartapps/kristopherkubicki/circadian-daylight.src/circadian-daylight.groovy
+++ b/smartapps/kristopherkubicki/circadian-daylight.src/circadian-daylight.groovy
@@ -166,7 +166,7 @@ def modeHandler(evt) {
             if(settings.dbright == true && ctbulb.currentValue("level") != bright) {
                 ctbulb.setLevel(bright)
             }
-            if(ctbulb.currentValue("colorTemperature") != ct) {
+            if(ctbulb.currentValue("colormode") != "ct" || ctbulb.currentValue("colorTemperature") != ct) {
                 ctbulb.setColorTemperature(ct)
             }
         }
@@ -177,7 +177,7 @@ def modeHandler(evt) {
         	if(settings.dbright == true && bulb.currentValue("level") != bright) {
                 bulb.setLevel(bright)
             }
-            if(bulb.currentValue("color") != hex) {
+            if((bulb.currentValue("colormode") != "xy" && bulb.currentValue("colormode") != "hs") || bulb.currentValue("color") != hex) {
             	color.value = bulb.currentValue("level")
             	bulb.setColor(color)
 			}

--- a/smartapps/kristopherkubicki/circadian-daylight.src/circadian-daylight.groovy
+++ b/smartapps/kristopherkubicki/circadian-daylight.src/circadian-daylight.groovy
@@ -100,9 +100,20 @@ def updated() {
 
 private def initialize() {
     log.debug("initialize() with settings: ${settings}")
-    if(ctbulbs) { subscribe(ctbulbs, "switch.on", modeHandler) }
-    if(bulbs) { subscribe(bulbs, "switch.on", modeHandler) }
-    if(dimmers) { subscribe(dimmers, "switch.on", modeHandler) }
+    if(ctbulbs) {
+		subscribe(ctbulbs, "switch.on", modeHandler)
+		subscribe(ctbulbs, "cdBrightness.true", modeHandler)
+		subscribe(ctbulbs, "cdColor.true", modeHandler)
+	}
+    if(bulbs) {
+		subscribe(bulbs, "switch.on", modeHandler)
+		subscribe(ctbulbs, "cdBrightness.true", modeHandler)
+		subscribe(ctbulbs, "cdColor.true", modeHandler)
+	}
+    if(dimmers) {
+		subscribe(dimmers, "switch.on", modeHandler)
+		subscribe(ctbulbs, "cdBrightness.true", modeHandler)
+	}
     if(dswitches) { subscribe(dswitches, "switch.off", modeHandler) }
     subscribe(location, "mode", modeHandler)
     


### PR DESCRIPTION
This opens up device handlers to add special attributes: cdBrightness and cdColor. Circadian Daylight will look at the value of these to determine if/how to adjust a bulb. Essentially, this allows an individual light to have tiles and custom commands for toggling color adjustments and dynamic brightness, allowing Circadian Daylight settings to be changed per-device, on the fly. 

The way the logic was written, devices without these capabilities should behave as if nothing as changed. 
